### PR TITLE
Fix log resolvers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ _ReSharper.*/
 *.user
 packages
 /.vs
+AssemblyInfo.cs

--- a/Rhino.Licensing.Tests/Rhino.Licensing.Tests.csproj
+++ b/Rhino.Licensing.Tests/Rhino.Licensing.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -8,6 +8,7 @@
     <RootNamespace>Rhino.Licensing.Tests</RootNamespace>
     <AssemblyName>Rhino.Licensing.Tests</AssemblyName>
     <FileAlignment>512</FileAlignment>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -32,7 +33,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">
-    <DefineConstants>DESKTOP;</DefineConstants>
+    <DefineConstants>DESKTOP</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -81,10 +82,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Rhino.Licensing\Rhino.Licensing.csproj">
-      <Project>{05EFD7EB-F0FB-4B65-8E4A-C8FF8DDC6A78}</Project>
-      <Name>Rhino.Licensing</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Rhino.Licensing\Rhino.Licensing.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Rhino.Licensing/LibLog.cs
+++ b/Rhino.Licensing/LibLog.cs
@@ -3,7 +3,7 @@
 //
 // https://github.com/damianh/LibLog
 //===============================================================================
-// Copyright © 2011-2015 Damian Hickey.  All rights reserved.
+// Copyright ï¿½ 2011-2015 Damian Hickey.  All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,7 @@
 // this can have unintended consequences of consumers of your library using your library to resolve a logger. If the
 // reason is because you want to open this functionality to other projects within your solution,
 // consider [InternalsVisibleTo] instead.
-// 
+//
 // Define LIBLOG_PROVIDERS_ONLY if your library provides its own logging API and you just want to use the
 // LibLog providers internally to provide built in support for popular logging frameworks.
 
@@ -95,7 +95,7 @@ namespace Rhino.Licensing.Logging
         /// <remarks>
         /// Note to implementers: the message func should not be called if the loglevel is not enabled
         /// so as not to incur performance penalties.
-        /// 
+        ///
         /// To check IsEnabled call Log with only LogLevel and check the return value, no event will be written.
         /// </remarks>
         bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception = null, params object[] formatParameters);
@@ -519,10 +519,10 @@ namespace Rhino.Licensing.Logging
         public static bool IsDisabled { get; set; }
 
         /// <summary>
-        /// Sets an action that is invoked when a consumer of your library has called SetCurrentLogProvider. It is 
+        /// Sets an action that is invoked when a consumer of your library has called SetCurrentLogProvider. It is
         /// important that hook into this if you are using child libraries (especially ilmerged ones) that are using
         /// LibLog (or other logging abstraction) so you adapt and delegate to them.
-        /// <see cref="SetCurrentLogProvider"/> 
+        /// <see cref="SetCurrentLogProvider"/>
         /// </summary>
         internal static Action<ILogProvider> OnCurrentLogProviderSet
         {
@@ -673,11 +673,21 @@ namespace Rhino.Licensing.Logging
     static readonly List<Tuple<IsLoggerAvailable, CreateLogProvider>> LogProviderResolvers =
                 new List<Tuple<IsLoggerAvailable, CreateLogProvider>>
             {
-            new Tuple<IsLoggerAvailable, CreateLogProvider>(SerilogLogProvider.IsLoggerAvailable, () => new SerilogLogProvider()),
-            new Tuple<IsLoggerAvailable, CreateLogProvider>(NLogLogProvider.IsLoggerAvailable, () => new NLogLogProvider()),
-            new Tuple<IsLoggerAvailable, CreateLogProvider>(Log4NetLogProvider.IsLoggerAvailable, () => new Log4NetLogProvider()),
-            new Tuple<IsLoggerAvailable, CreateLogProvider>(EntLibLogProvider.IsLoggerAvailable, () => new EntLibLogProvider()),
-            new Tuple<IsLoggerAvailable, CreateLogProvider>(LoupeLogProvider.IsLoggerAvailable, () => new LoupeLogProvider()),
+            new Tuple<IsLoggerAvailable, CreateLogProvider>(
+                SerilogLogProvider.IsLoggerAvailable,
+                () => new SerilogLogProvider()),
+            new Tuple<IsLoggerAvailable, CreateLogProvider>(
+                NLogLogProvider.IsLoggerAvailable,
+                () => new NLogLogProvider()),
+            new Tuple<IsLoggerAvailable, CreateLogProvider>(
+                Log4NetLogProvider.IsLoggerAvailable,
+                () => new Log4NetLogProvider()),
+            //new Tuple<IsLoggerAvailable, CreateLogProvider>(
+            //    EntLibLogProvider.IsLoggerAvailable,
+            //    () => new EntLibLogProvider()),
+            new Tuple<IsLoggerAvailable, CreateLogProvider>(
+                LoupeLogProvider.IsLoggerAvailable,
+                () => new LoupeLogProvider()),
             };
 
 #if !LIBLOG_PROVIDERS_ONLY
@@ -855,7 +865,7 @@ namespace Rhino.Licensing.Logging.LogProviders
     internal class NLogLogProvider : LogProviderBase
     {
         private readonly Func<string, object> _getLoggerByNameDelegate;
-        private static bool s_providerIsAvailableOverride = true;
+        private static bool s_providerIsAvailableOverride = false;
 
         [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "LogManager")]
         [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "NLog")]
@@ -1204,7 +1214,7 @@ namespace Rhino.Licensing.Logging.LogProviders
     internal class Log4NetLogProvider : LogProviderBase
     {
         private readonly Func<string, object> _getLoggerByNameDelegate;
-        private static bool s_providerIsAvailableOverride = true;
+        private static bool s_providerIsAvailableOverride = false;
 
         [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "LogManager")]
         public Log4NetLogProvider()
@@ -1588,7 +1598,7 @@ namespace Rhino.Licensing.Logging.LogProviders
     internal class EntLibLogProvider : LogProviderBase
     {
         private const string TypeTemplate = "Microsoft.Practices.EnterpriseLibrary.Logging.{0}, Microsoft.Practices.EnterpriseLibrary.Logging";
-        private static bool s_providerIsAvailableOverride = true;
+        private static bool s_providerIsAvailableOverride = false;
         private static readonly Type LogEntryType;
         private static readonly Type LoggerType;
         private static readonly Type TraceEventTypeType;
@@ -1768,7 +1778,7 @@ namespace Rhino.Licensing.Logging.LogProviders
     internal class SerilogLogProvider : LogProviderBase
     {
         private readonly Func<string, object> _getLoggerByNameDelegate;
-        private static bool s_providerIsAvailableOverride = true;
+        private static bool s_providerIsAvailableOverride = false;
         private static Func<string, string, IDisposable> _pushProperty;
 
         [SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "Serilog")]
@@ -2037,7 +2047,7 @@ namespace Rhino.Licensing.Logging.LogProviders
             params object[] args
             );
 
-        private static bool s_providerIsAvailableOverride = true;
+        private static bool s_providerIsAvailableOverride = false;
         private readonly WriteDelegate _logWriteDelegate;
 
         public LoupeLogProvider()
@@ -2197,9 +2207,9 @@ namespace Rhino.Licensing.Logging.LogProviders
 
         /// <summary>
         /// Some logging frameworks support structured logging, such as serilog. This will allow you to add names to structured data in a format string:
-        /// For example: Log("Log message to {user}", user). This only works with serilog, but as the user of LibLog, you don't know if serilog is actually 
-        /// used. So, this class simulates that. it will replace any text in {curly braces} with an index number. 
-        /// 
+        /// For example: Log("Log message to {user}", user). This only works with serilog, but as the user of LibLog, you don't know if serilog is actually
+        /// used. So, this class simulates that. it will replace any text in {curly braces} with an index number.
+        ///
         /// "Log {message} to {user}" would turn into => "Log {0} to {1}". Then the format parameters are handled using regular .net string.Format.
         /// </summary>
         /// <param name="messageBuilder">The message builder.</param>

--- a/Rhino.Licensing/Rhino.Licensing.csproj
+++ b/Rhino.Licensing/Rhino.Licensing.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -7,12 +7,15 @@
     <Description>Licensing Framework for .NET.</Description>
     <Authors>Ayende Rahien + Contributors</Authors>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageProjectUrl>https://github.com/ayende/rhino-licensing</PackageProjectUrl>
-    <PackageTags>Licencing</PackageTags>
+    <PackageProjectUrl>https://github.com/chocolatey/rhino-licensing</PackageProjectUrl>
+    <Version>1.4.0</Version>
+    <PackageTags>Licensing</PackageTags>
     <PackageId>Rhino.Licensing</PackageId>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\ayende-open-source.snk</AssemblyOriginatorKeyFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <DefineConstants>LIBLOG_PROVIDERS_ONLY</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
@@ -82,12 +85,6 @@
 
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.12" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Include="$(SolutionDir)\Solution Items\SolutionInfo.cs">
-      <Link>Properties\SolutionInfo.cs</Link>
-    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/default.ps1
+++ b/default.ps1
@@ -1,12 +1,12 @@
-properties { 
+properties {
   $product_name = "Rhino.Licensing"
   $base_dir = Resolve-Path .
   $lib_dir = "$base_dir\SharedLibs"
   $build_dir = "$base_dir\build"
   $buildartifacts_dir = "$build_dir\"
   $sln_file = "$base_dir\$product_name.sln"
-  $version = "1.3.0.0"
-  $humanReadableversion = "1.3"
+  $version = "1.4.0.0"
+  $humanReadableversion = "1.4"
   $tools_dir = "$base_dir\Tools"
   $release_dir = "$base_dir\Release"
   $uploadCategory = "Rhino-Mocks"
@@ -19,7 +19,7 @@ properties {
   $title = "Rhino Licensing $version"
   $copyright = "Hibernating Rhinos & Ayende Rahien 2004 - 2009"
   $description = "Licensing Framework for .NET"
-} 
+}
 
 include .\psake_ext.ps1
 
@@ -35,15 +35,15 @@ task Nuget-Publish  { #-depends Nuget-Pack
   exec { invoke-expression "$nuget push $release_dir\$product_name.$humanReadableversion.nupkg" }
 }
 
-task Clean { 
+task Clean {
   write-host "lib folder is $lib_dir"
 
-  remove-item -force -recurse $buildartifacts_dir -ErrorAction SilentlyContinue 
-  remove-item -force -recurse $release_dir -ErrorAction SilentlyContinue 
-} 
+  remove-item -force -recurse $buildartifacts_dir -ErrorAction SilentlyContinue
+  remove-item -force -recurse $release_dir -ErrorAction SilentlyContinue
+}
 
-task Init -depends Clean { 
-	
+task Init -depends Clean {
+
 	Generate-Assembly-Info `
 		-file "$base_dir\Rhino.Licensing\Properties\AssemblyInfo.cs" `
 		-title $title `
@@ -52,7 +52,7 @@ task Init -depends Clean {
 		-product $title `
 		-version $version `
 		-copyright $copyright
-		
+
 	Generate-Assembly-Info `
 		-file "$base_dir\Rhino.Licensing.Tests\Properties\AssemblyInfo.cs" `
 		-title $title `
@@ -61,7 +61,7 @@ task Init -depends Clean {
 		-product $title `
 		-version $version `
 		-copyright $copyright
-		
+
 	Generate-Assembly-Info `
 		-file "$base_dir\Rhino.Licensing.AdminTool\Properties\AssemblyInfo.cs" `
 		-title $title `
@@ -70,7 +70,7 @@ task Init -depends Clean {
 		-product $title `
 		-version $version `
 		-copyright $copyright
-		
+
 	Generate-Assembly-Info `
 		-file "$base_dir\Rhino.Licensing.AdminTool.Tests\Properties\AssemblyInfo.cs" `
 		-title $title `
@@ -80,24 +80,22 @@ task Init -depends Clean {
 		-version $version `
 		-clsCompliant "false" `
 		-copyright $copyright
-		
-	new-item $release_dir -itemType directory 
-	new-item $buildartifacts_dir -itemType directory 
-	cp $tools_dir\xunit\*.* $build_dir
-} 
 
-task Compile -depends Init { 
-  exec { msbuild /p:OutDir=$buildartifacts_dir $sln_file  }
-} 
+	new-item $release_dir -itemType directory
+	new-item $buildartifacts_dir -itemType directory
+}
+
+task Compile -depends Init {
+  exec { & dotnet build -o $buildartifacts_dir -c Release $sln_file }
+}
 
 task Test -depends Compile {
   $old = pwd
   cd $build_dir
-  
-  exec { invoke-expression "$xunit $build_dir\Rhino.Licensing.Tests.dll /noshadow" }  
-  exec { invoke-expression "$xunit $build_dir\Rhino.Licensing.AdminTool.Tests.dll /noshadow" }
-  
-  cd $old		
+
+  exec { & dotnet test $sln_file }
+
+  cd $old
 }
 
 task Release -depends Test {
@@ -107,13 +105,13 @@ task Release -depends Test {
 		$build_dir\Rhino.Licensing.xml `
 		license.txt `
 		acknowledgements.txt
-		
+
 	& $tools_dir\zip.exe -9 -A -j `
 		$release_dir\Rhino.Licensing-AdminTool-$humanReadableversion-Build-$env:ccnetnumericlabel.zip `
 		$build_dir\Rhino.Licensing.AdminTool.exe `
 		license.txt `
 		acknowledgements.txt
-		
+
 	if ($lastExitCode -ne 0) {
         throw "Error: Failed to execute ZIP command"
     }
@@ -121,9 +119,9 @@ task Release -depends Test {
 
 task Upload -depend Release {
 	if (Test-Path $uploadScript ) {
-		$log = git log -n 1 --oneline		
+		$log = git log -n 1 --oneline
 		msbuild $uploadScript /p:Category=$uploadCategory "/p:Comment=$log" "/p:File=$release_dir\Rhino.Mocks-$humanReadableversion-Build-$env:ccnetnumericlabel.zip"
-		
+
 		if ($lastExitCode -ne 0) {
 			throw "Error: Failed to publish build"
 		}


### PR DESCRIPTION
Log resolution behaviour had been deliberately turned off at some point, which made this lib accidentally dependent on SeriLog.

Fix is to disable the overrides and comment out one of the provider registrations, which was throwing errors from its static constructor.

Fixes #2 