### PR TITLE
(#7) Make signing algorithm consistent, default to SHA1, and selectable by downstream projects

### DIFF
--- a/Rhino.Licensing/LicenseGenerator.cs
+++ b/Rhino.Licensing/LicenseGenerator.cs
@@ -43,7 +43,7 @@ namespace Rhino.Licensing
                 var publicKeyEl = doc.CreateElement("license-server-public-key");
                 license.AppendChild(publicKeyEl);
                 publicKeyEl.InnerText = publicKey;
-                
+
                 var nameEl = doc.CreateElement("name");
                 license.AppendChild(nameEl);
                 nameEl.InnerText = name;
@@ -114,14 +114,14 @@ namespace Rhino.Licensing
         {
             using (var rsa = new RSACryptoServiceProvider())
             {
-                RSAKeyExtensions.FromXmlString(rsa,privateKey);
+                RSAKeyExtensions.FromXmlString(rsa, privateKey);
                 var doc = CreateDocument(id, name, expirationDate, attributes, licenseType);
 
                 var signature = GetXmlDigitalSignature(doc, rsa, algorithm);
                 doc.FirstChild.AppendChild(doc.ImportNode(signature, true));
 
                 var ms = new MemoryStream();
-                var writer = XmlWriter.Create(ms,new XmlWriterSettings
+                var writer = XmlWriter.Create(ms, new XmlWriterSettings
                 {
                     Indent = true,
                     Encoding = Encoding.UTF8
@@ -178,7 +178,7 @@ namespace Rhino.Licensing
             var idAttr = doc.CreateAttribute("id");
             license.Attributes.Append(idAttr);
             idAttr.Value = id.ToString();
-        
+
             var expirDateAttr = doc.CreateAttribute("expiration");
             license.Attributes.Append(expirDateAttr);
             expirDateAttr.Value = expirationDate.ToString("yyyy-MM-ddTHH:mm:ss.fffffff", CultureInfo.InvariantCulture);
@@ -186,7 +186,7 @@ namespace Rhino.Licensing
             var licenseAttr = doc.CreateAttribute("type");
             license.Attributes.Append(licenseAttr);
             licenseAttr.Value = licenseType.ToString();
-            
+
             var nameEl = doc.CreateElement("name");
             license.AppendChild(nameEl);
             nameEl.InnerText = name;

--- a/Rhino.Licensing/LicenseGenerator.cs
+++ b/Rhino.Licensing/LicenseGenerator.cs
@@ -17,9 +17,9 @@ namespace Rhino.Licensing
         private readonly string privateKey;
 
         /// <summary>
-        /// Creates a new instance of <seealso cref="LicenseGenerator"/>. 
+        /// Creates a new instance of <see cref="LicenseGenerator"/>.
         /// </summary>
-        /// <param name="privateKey">private key of the product</param>
+        /// <param name="privateKey">The private key of the product</param>
         public LicenseGenerator(string privateKey)
         {
             this.privateKey = privateKey;
@@ -29,8 +29,8 @@ namespace Rhino.Licensing
         /// Generates a new floating license.
         /// </summary>
         /// <param name="name">Name of the license holder</param>
-        /// <param name="publicKey">public key of the license server</param>
-        /// <returns>license content</returns>
+        /// <param name="publicKey">The public key of the license server</param>
+        /// <returns>The generated license XML string</returns>
         public string GenerateFloatingLicense(string name, string publicKey)
         {
             using (var rsa = new RSACryptoServiceProvider())
@@ -64,27 +64,27 @@ namespace Rhino.Licensing
         }
 
         /// <summary>
-        /// Generates a new license
+        /// Generates a new license with no attributes using SHA1 as the signing algorithm.
         /// </summary>
-        /// <param name="name">name of the license holder</param>
+        /// <param name="name">Name of the license holder</param>
         /// <param name="id">Id of the license holder</param>
-        /// <param name="expirationDate">expiry date</param>
-        /// <param name="licenseType">type of the license</param>
-        /// <returns></returns>
+        /// <param name="expirationDate">License expiry date</param>
+        /// <param name="licenseType">Type of the license</param>
+        /// <returns>The generated license XML string</returns>
         public string Generate(string name, Guid id, DateTime expirationDate, LicenseType licenseType)
         {
             return Generate(name, id, expirationDate, new Dictionary<string, string>(), licenseType);
         }
 
         /// <summary>
-        /// Generates a new license
+        /// Generates a new license using SHA1 as the signing algorithm.
         /// </summary>
-        /// <param name="name">name of the license holder</param>
+        /// <param name="name">Name of the license holder</param>
         /// <param name="id">Id of the license holder</param>
-        /// <param name="expirationDate">expiry date</param>
-        /// <param name="licenseType">type of the license</param>
-        /// <param name="attributes">extra information stored as key/valye in the license file</param>
-        /// <returns></returns>
+        /// <param name="expirationDate">License expiry date</param>
+        /// <param name="licenseType">Type of the license</param>
+        /// <param name="attributes">Extra information stored as key/value in the license file</param>
+        /// <returns>The generated license XML string</returns>
         public string Generate(string name, Guid id, DateTime expirationDate, IDictionary<string, string> attributes, LicenseType licenseType)
             => Generate(name, id, expirationDate, attributes, licenseType, SigningAlgorithm.SHA1);
 
@@ -96,7 +96,7 @@ namespace Rhino.Licensing
         /// <param name="expirationDate">License expiry date</param>
         /// <param name="licenseType">Type of the license</param>
         /// <param name="algorithm">Signing algorithm to use for signing the XML</param>
-        /// <returns>The generated license string</returns>
+        /// <returns>The generated license XML string</returns>
         public string Generate(string name, Guid id, DateTime expirationDate, LicenseType licenseType, SigningAlgorithm algorithm)
             => Generate(name, id, expirationDate, new Dictionary<string, string>(), licenseType, algorithm);
 

--- a/Rhino.Licensing/Rhino.Licensing.csproj
+++ b/Rhino.Licensing/Rhino.Licensing.csproj
@@ -16,6 +16,11 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <DefineConstants>LIBLOG_PROVIDERS_ONLY</DefineConstants>
+    <LangVersion>9.0</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" $(TargetFramework) == 'net40' ">
+    <DefineConstants>NET40</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/Rhino.Licensing/SigningAlgorithm.cs
+++ b/Rhino.Licensing/SigningAlgorithm.cs
@@ -1,0 +1,18 @@
+namespace Rhino.Licensing
+{
+    /// <summary>
+    /// The algorithm to use when signing licenses.
+    /// </summary>
+    public enum SigningAlgorithm
+    {
+        SHA1,
+
+#if !NET40
+        SHA256,
+
+        SHA384,
+
+        SHA512
+#endif
+    }
+}


### PR DESCRIPTION
## Changes

- Added `SigningAlgorithm` enum
- Added overloads to `LicenseGenerator.Generate()` to allow selection of the signing algorithm used
- Explicitly set the signing algorithms to SHA1 by default to ensure consistent behaviour with the original .NET 4.0 implementation
- Updated some documentation comments and cleaned up some existing doc comments in the source

Note: in the `net40` build, only SHA1 is available. It seems that SHA256 is completely unavailable in .NET 4.0. Attempting to reference the SHA256 and newer algorithm URLs gave me a lot of errors . I've gated the newer algorithms behind a compiler check for the target framework so that it still compiles for .NET 4.0.

## Testing

I tested this by loading the generated DLL on Windows PowerShell. It should work in newer versions of PowerShell (and .NET) as well, but I had some annoying issues getting the additional dependencies to load correctly in later versions of PowerShell.

- Run `build.ps1` to have the DLLs built and tested (run tests in an administrative shell if you run into errors, some of the .NET 4.0/4.8 tests 
- Run the following code in a PowerShell session to generate a private key and two licenses, one with the default SHA1, and one with SHA256.

<details>
<summary>Show script</summary>

```ps1
Add-Type -Path ./Rhino.Licensing/bin/Debug/net48/Rhino.Licensing.dll

$rsa = [System.Security.Cryptography.RSACryptoServiceProvider]::new()
$key = $rsa.ToXmlString($true)

$generator = [Rhino.Licensing.LicenseGenerator]::new($key)
$name = "Customer Name"
$guid = New-Guid
$expiry = [datetime]::UtcNow.AddYears(1)
$type = [Rhino.Licensing.LicenseType]::Business

# Generate SHA1 (default)
$generator.Generate($name, $guid, $expiry, $type)

# Generate SHA256
$generator.Generate($name, $guid, $expiry, $type, [Rhino.Licensing.SigningAlgorithm]::SHA256)
```
</details>

- Examine the generated XML strings.

Verify that the first looks something like this (note the `sha1` in the Algorithm URLs):

<details>
<summary>SHA1 license XML</summary>

```xml
<?xml version="1.0" encoding="utf-8"?>
<license id="8bd0cae9-096e-472f-821b-207c7829ac95" expiration="2022-11-16T17:50:56.8216874" type="Business">
  <name>Customer Name</name>
  <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
    <SignedInfo>
      <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />
      <SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1" />
      <Reference URI="">
        <Transforms>
          <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
        </Transforms>
        <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
        <DigestValue>lQ1rKrIIbMv7Ey/L5vy1x4diSYo=</DigestValue>
      </Reference>
    </SignedInfo>
    <SignatureValue>W+qtomGJYoOAhxoziYkfu6tunUw+8E6Kq14mA7a4aSVd8U2uDR+CPIPUrpbnpktji21sr71BVvhf8isk2KTGFy8a6dyPTrygXBOWvD+BAPYTD55ONydMv86j8pjIzP5zQVAHu3ALb4jUmY8JOxLwyPDshun7i/Wyk8QiZdsFwMM=</SignatureValue>
  </Signature>
</license>
```
</details>

And the second looks like this (note the `sha256` in the Algorithm URLs):

<details>
<summary>SHA256 license XML</summary>

```xml
<?xml version="1.0" encoding="utf-8"?>
<license id="8bd0cae9-096e-472f-821b-207c7829ac95" expiration="2022-11-16T17:50:56.8216874" type="Business">
  <name>Customer Name</name>
  <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
    <SignedInfo>
      <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />
      <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" />
      <Reference URI="">
        <Transforms>
          <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
        </Transforms>
        <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
        <DigestValue>1nZ+Mr7YJwPnK2CK8OHX2mQPqBl0Fklfn5gQCqKkTv0=</DigestValue>
      </Reference>
    </SignedInfo>
    <SignatureValue>bmiLvtRMLnEul+EbidGOeJptPJeos6aCvB39I+0smGrCmysQJT/GS+y+Z+CkWKmTFyiYw/oZQGhoE9C+rbYZo0d8UL2nDSwDOQ9TozC3eBbVirPKeFXWV6/8XMh5tO8COKCxdwph0+XOt8d+5mqsZa+ethcw9PIi53rt40dH9Cs=</SignatureValue>
  </Signature>
</license>
```
</details>

For further verification, I also used the Chocolatey key to generate valid Chocolatey licenses and verified that `choco` recognises licenses generated in this way, both when they are SHA1 and SHA256.