### PR TITLE
(maint) Update to prod VCS name

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -16,7 +16,7 @@ object RhinoLicensingBuild : BuildType({
 
     params {
         param("teamcity.git.fetchAllHeads", "true")
-        param("env.Git_Branch", "%teamcity.build.vcs.branch.RhinoLicensingAnsible_RhinoAnsibleVcsRoot%")
+        param("env.Git_Branch", "%teamcity.build.vcs.branch.RhinoLicensing_RhinoLicensingVcsRoot%")
         param("env.vcsroot.branch", "%vcsroot.branch%")
     }
 


### PR DESCRIPTION
## Description Of Changes

Update the configured TeamCity VCS name to the live one.

## Motivation and Context

Build will not run when it's using the test one.

## Testing

Tested via manual edit.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Related to #10

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
