### PR TITLE
(#10) Update to the public recipe package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # Rhino-Licensing
-A software licensing framework [https://www.hibernatingrhinos.com/oss/rhino-licensing](https://www.hibernatingrhinos.com/oss/rhino-licensing) [http://ayende.com](http://ayende.com)
 
-how to build
----------------
-The solution can be directly compiled with visual studio
-note: the psake build is currently broken
+A fork of the original Rhino.Licensing software licensing framework used for [Chocolatey](https://github.com/chocolatey/choco).
 
-To create the nuget package run buildNuget.bat
+[https://www.hibernatingrhinos.com/oss/rhino-licensing](https://www.hibernatingrhinos.com/oss/rhino-licensing) [http://ayende.com](http://ayende.com)
 
+## Building the Project
 
-how to run the tests
----------------
-Please note that in order to run the tests you must either run them in the context of the administrator or run the following command:
-netsh http add urlacl url=http://+:19292/license user=YOUR_USER_NAME
+Visual Studio or VS Code can be used to build the solution.
+Note that the `Rhino.Licensing.AdminTool*` projects are not currently part of the solution or presently being maintained.
 
+A full build, test, and pack run can be started using the `build.ps1` PowerShell script.
 
-acknowledgements
----------------
-Rhino Licensing is making use of the excellent log4net logging framework
+## Testing
+
+Running the `build.ps1` will run unit tests for the project.
+
+## Acknowledgements
+
+Rhino Licensing is making use of the excellent log4net logging framework.

--- a/recipe.cake
+++ b/recipe.cake
@@ -1,4 +1,4 @@
-#load nuget:https://hermes.chocolatey.org:8443/repository/choco-internal-testing/?package=cake-chocolatey-recipe&prerelease&version=0.1.0-unstable0082
+#load nuget:?package=Chocolatey.Cake.Recipe&version=0.2.1
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -11,12 +11,7 @@
 // RECIPE SETUP
 ///////////////////////////////////////////////////////////////////////////////
 
-
 Environment.SetVariableNames();
-var packageSources = new List<PackageSourceData>();
-var nugetDevUrl = EnvironmentVariable("NUGETDEV_SOURCE");
-
-packageSources.Add(new PackageSourceData(Context, "NugetDev", nugetDevUrl, FeedType.NuGet, isRelease: false));
 
 Func<FilePathCollection> getProjectsToPack = ()=> GetFiles(BuildParameters.SourceDirectoryPath + "/**/*.csproj")
         - GetFiles(BuildParameters.RootDirectoryPath + "/tools/**/*.csproj")
@@ -42,9 +37,7 @@ BuildParameters.SetParameters(
     shouldRunInspectCode: false,
     treatWarningsAsErrors: false,
     testDirectoryPath: "./test",
-    packageSourceDatas: packageSources,
     shouldRunDotNetCorePack: true,
-    shouldRunDupFinder: false,
     getProjectsToPack: getProjectsToPack);
 
 BuildParameters.PrintParameters(Context);


### PR DESCRIPTION
## Description Of Changes

- Updated to the public Chocolatey.Cake.Recipe package
- Removed the source configurations as we were setting the same
  as the defaults.
- Included some readme updates, that thing hasn't been updated in eons.

## Motivation and Context

- We forgot to come back and update the recipe package used in the previous PR.
- There were some README changes needed, that file was _very_ old and no longer useful to anyone.

## Testing

1. Build script run to ensure all tests are still passing and new build recipe functions properly.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

#10

## Change Checklist

* [ ] Requires a change to the documentation
* [x] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
