### PR TITLE
(build) Update CI configuration

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -12,7 +12,10 @@ project {
 object RhinoLicensingBuild : BuildType({
     name = "Rhino.Licensing Build"
 
-    artifactRules = "code_drop/TestResults/issues-report.html"
+    artifactRules = """
+        code_drop/TestResults/issues-report.html
+        code_drop/Packages/**/*.nupkg
+    """.trimIndent()
 
     params {
         param("teamcity.git.fetchAllHeads", "true")
@@ -48,7 +51,7 @@ object RhinoLicensingBuild : BuildType({
                         [System.Environment]::GetEnvironmentVariable('PATH', 'Machine')
                     ) -join ';'
 
-                    & ./build.ps1 -Verbosity Diagnostic
+                    & ./build.ps1 -Verbosity Diagnostic -Target CI
                 """.trimIndent()
             }
             noProfile = false

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,13 @@
+assembly-versioning-scheme: MajorMinorPatch
+branches:
+  main:
+    increment: Minor
+    regex: '^(master|main)$'
+    tag: beta
+    source-branches: []
+continuous-delivery-fallback-tag: alpha
+increment: Minor
+mode: ContinuousDeployment
+ignore:
+  sha: []
+merge-message-formats: {}


### PR DESCRIPTION
## Description Of Changes

- Set `-Target CI` on the teamcity run to ensure packages are published from TeamCity
- Add gitversion.yml file to define versioning scheme

## Motivation and Context

Because this repo doesn't use GitFlow, we need to manually set some things in the gitversion.yml file to ensure our versions have the correct prerelease tags. We also need to set the `-Target` appropriately for the build script so that we actually have it publishing packages from our teamcity server.

## Testing

1. Ran build.ps1 from the PR branch, version of the generated package was calculated as including the branch name, which is fine.
2. Ran build.ps1 with the changes merged to a local master branch to verify versioning, version calculated looks correct in the build log.

**NOTE:** Currently the generated `nupkg` file will still have a slightly wrong version number, I was seeing things like `1.6.0-beta0011` for example. I have consulted @gep13's infinite wisdom, and we have filed a follow up issue in the Chocolatey.Cake.Recipe to resolve this. Until that gets fixed there and merged we'll have a few slightly odd nupkg versions.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

#10

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.