### PR TITLE
(maint) Enable building on PRs

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1,4 +1,5 @@
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.powerShell
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
@@ -61,6 +62,16 @@ object RhinoLicensingBuild : BuildType({
 
     triggers {
         vcs {
+        }
+    }
+
+    features {
+        pullRequests {
+            provider = github {
+                authType = token {
+                    token = "%system.GitHubPAT%"
+                }
+            }
         }
     }
 })


### PR DESCRIPTION
## Description Of Changes

Enable PR builds for TeamCity

## Motivation and Context

Makes things a bit easier to double check and will let us know if something breaks unexpectedly.

## Testing

This configuration entry is a direct copy of the `choco` repository one and they're running on the same TeamCity server, so it should work just the same.

## Change Types Made

* [x] Build improvement
* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Just a lil build process improvement, I don't think we need an issue for it tbh.

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.