### PR TITLE
(#21) Fix build settings so that DLLs get tagged

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -1,4 +1,4 @@
-#load nuget:?package=Chocolatey.Cake.Recipe&version=0.4.2
+#load nuget:?package=Chocolatey.Cake.Recipe&version=0.13.3
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -37,7 +37,7 @@ BuildParameters.SetParameters(
     shouldRunInspectCode: false,
     treatWarningsAsErrors: false,
     testDirectoryPath: "./test",
-    shouldRunDotNetCorePack: true,
+    shouldRunDotNetPack: true,
     getProjectsToPack: getProjectsToPack);
 
 BuildParameters.PrintParameters(Context);
@@ -54,4 +54,4 @@ ToolSettings.SetToolSettings(context: Context);
 // RUN IT!
 ///////////////////////////////////////////////////////////////////////////////
 
-Build.RunDotNetCore();
+Build.RunDotNet();

--- a/src/Rhino.Licensing/Rhino.Licensing.csproj
+++ b/src/Rhino.Licensing/Rhino.Licensing.csproj
@@ -13,7 +13,6 @@
     <PackageId>Rhino.Licensing</PackageId>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\ayende-open-source.snk</AssemblyOriginatorKeyFile>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <DefineConstants>LIBLOG_PROVIDERS_ONLY</DefineConstants>
     <LangVersion>8.0</LangVersion>


### PR DESCRIPTION
## Description Of Changes

Update Rhino.Licensing project file to tag the built DLLs

## Motivation and Context

Without the DLL being tagged, they can't be as readily used.

## Testing

1. Ran `$env:TEAMCITY_PROJECT_NAME = 'Rhino'` to set an Environment variable to skip a few failing tests (they're being removed in #20 anyways)
2. Ran `./build.ps1`
3. Navigate to `./code_drop/temp/_PublishedLibs/Rhino.Licensing/net48/`
4. Right click `Rhino.Licensing.dll`
5. Select Properties
6. On the Details tab, File version should be `1.6.0`

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #21

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
