### PR TITLE
(#23) Bump TeamCity configs version

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -4,7 +4,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.powerShell
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
 
-version = "2021.2"
+version = "2022.04"
 
 project {
     buildType(RhinoLicensingBuild)


### PR DESCRIPTION
## Description Of Changes

This PR bumps the configs version for the TeamCity project to `2022.04`.

## Motivation and Context

The configs version needs to match what the server is expecting.

## Testing

* I've tested this in my local TeamCity instance
* Other projects have this version

## Change Types Made

~~* [ ] Bug fix (non-breaking change)~~

* [x] Feature / Enhancement (non-breaking change)

~~* [ ] Breaking change (fix or feature that could cause existing functionality to change)~~
~~* [ ] PowerShell code changes.~~

## Related Issue

Fixes #23

## Change Checklist

~~* [ ] Requires a change to the documentation~~
~~* [ ] Documentation has been updated~~
~~* [ ] Tests to cover my changes, have been added~~
~~* [ ] All new and existing tests passed.~~
~~* [ ] PowerShell v2 compatibility checked.~~